### PR TITLE
minor feature: Relative time triggers for auto action

### DIFF
--- a/game.js
+++ b/game.js
@@ -883,6 +883,7 @@ function beginNextRun(opt_challenge) {
   for(var i = 0; i < state.automaton_autoactions.length; i++) {
     state.automaton_autoactions[i].done = 0;
     state.automaton_autoactions[i].time2 = 0;
+    state.automaton_autoactions[i].getTrigger().triggeredAt = undefined;
   }
 
   //updateAbilitiesUI();
@@ -2844,6 +2845,9 @@ function autoActionTriggerConditionReached(index, o) {
   if(trigger.type == 4 && state.c_runtime >= trigger.time) {
     return true;
   }
+  if(trigger.type == 6 && state.c_runtime >= trigger.getTime()) { // relative time
+    return true;
+  }
   return false;
 }
 
@@ -2982,6 +2986,7 @@ function doAutoActions() {
     if(o.done >= 3) continue;
     if(!o.enabled) continue;
     var triggered = autoActionTriggerConditionReached(i, o);
+    if(triggered && o.done == 0) o.getTrigger().triggeredAt = state.c_runtime; // for relative time auto actions
     var triggered2 = o.done == 1 && state.c_runtime >= o.time2;
     var triggered3 = o.done == 2 && state.c_runtime >= o.time2;
     if(triggered && !o.getEffect().enable_blueprint) {
@@ -3663,9 +3668,9 @@ function nextEventTime(opt_remaining_tick_length) {
         addtime(0.1, 'auto-action 0');
       }
       var trigger = o.getTrigger();
-      if(trigger.type == 4 && o.done == 0) {
+      if((trigger.type == 4 || trigger.type == 6) && o.done == 0) {
         //if(trigger.time - state.c_runtime < 60) continue; // don't overshoot this if it was e.g. disabled through some other way, else computing a long time interval will go very slow since this will keep trying to add a small time interval forever
-        addtime(trigger.time - state.c_runtime, 'auto-action', true);
+        addtime(trigger.getTime() - state.c_runtime, 'auto-action', true);
       }
       if(o.done > 0 && o.done < 3) {
         addtime(o.time2 - state.c_runtime, 'auto-action2', true);

--- a/main.js
+++ b/main.js
@@ -25,7 +25,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // -sub: 0..any: does not change the numeric version code. if non-0, adds 'b', 'c'. ... to the version name. Should not affect savegame format. Cosmetic changes only. Version name including this part is appended to CSS URL query part to ensure no stale cached CSS file is used.
 var version_major = 0; // 0..61
 var version_minor = 16; // 0..4095
-var version_patch = 1; // 0..63
+var version_patch = 2; // 0..63
 var version_sub = 0; // 0=no suffix, 1=b, 2=c, ...
 
 var version = 262144 * (version_major + 2) + 64 * version_minor + version_patch;

--- a/save.js
+++ b/save.js
@@ -754,6 +754,9 @@ function encState(state, opt_raw_only) {
     processTime(trigger.time);
     processUint(trigger.upgrade_level);
     processUint(trigger.crop_count);
+    processUint(trigger.relativeTo);
+    processTime(trigger.relativeTime);
+    processTime(trigger.triggeredAt);
     processStructEnd();
   };
 
@@ -2363,7 +2366,13 @@ function decState(s) {
     trigger.time = processTime();
     if(save_version >= 262144*2+64*13+2) trigger.upgrade_level = processUint();
     if(save_version >= 262144*2+64*13+2) trigger.crop_count = processUint();
+    if(save_version >= 262144*2+64*16+2) { 
+        trigger.relativeTo = processUint();
+        trigger.relativeTime = processTime();
+        trigger.triggeredAt = processTime();
+    }
     if(save_version >= 262144*2+64*13+2) processStructEnd();
+    
   };
 
   var processEffect = function(effect) {

--- a/state.js
+++ b/state.js
@@ -493,6 +493,15 @@ function AutoActionTriggerState() {
 
   this.upgrade_level = 1; // upgrade level for the 'upgraded crop' trigger type
   this.crop_count = 1; // for planted and fullgrown trigger types: how many of this crop
+
+  this.triggeredAt = undefined; // for relative time auto actions, time this trigger was activated
+  this.relativeTo = 0; // autoaction to reference from for relative time actions
+  this.relativeTime = 0; // difference from reference (must be positive)
+ 
+  this.getTime = function() {
+    if(this.type == 4) return this.time;
+    if(this.type == 6) return state.automaton_autoactions[this.relativeTo].getTrigger().triggeredAt + this.relativeTime;
+  }
 }
 
 // a single set of auto action effect settings, for a single season


### PR DESCRIPTION
Add another trigger type to auto actions, to make an action trigger x time after y action occurs.

I have been wishing for this feature for a long time, so I decided to write it. I've been playing with it for a few days and it appears to be working well (it might even be more stable during offline time), and I haven't been able to find any more bugs.

I chose to implement it as triggering after a specific action to be as explicit as possible. The other option I considered was making them trigger after the previous (and in 4 always triggers on 3) action in the list, which is simpler on user input but has less options.

<img width="607" height="636" alt="Auto Action UI" src="https://github.com/user-attachments/assets/bad732f4-c1b3-4f49-8954-d4e9650eff33" />
<img width="482" height="274" alt="Trigger config UI" src="https://github.com/user-attachments/assets/87600854-9b53-4481-bc5e-fa084e2eba20" />
